### PR TITLE
add support for configuration via environment variables.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/examples
+*.md
+*.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM scratch
 WORKDIR /
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY basic-auth-reverse-proxy /basic-auth-reverse-proxy
+COPY basic-auth-reverse-proxy .
+COPY ./assets/authn.yaml .
 
 ENTRYPOINT [ "/basic-auth-reverse-proxy" ]
+CMD ["serve"]

--- a/README.md
+++ b/README.md
@@ -41,3 +41,50 @@ $ curl http://Angel:Barrera@localhost:11811/get
   "url": "https://localhost:11811/get"
 }
 ```
+
+## Configuration
+
+The server can be configured via a file or environment variables.
+
+### File
+
+The configuration file is parsed as YAML input. The default location is a file
+named *authn.yaml* in the current working directory.
+The file contains authentication principals for the reverse proxy.
+
+```yaml
+---
+users:
+  - username: Angel
+    password: Barrera
+  - username: Pepe
+    password: Gotera
+```
+
+### Environment variables
+
+The environment variables containing configuration values all have the prefix
+**BARP_**. Both daemon settings as well as authentication principals can be
+provided this way:
+
+* **BARP_UPSTREAM**
+
+  The proxied URL
+
+* **BARP_PORT**
+
+  The port to bind to
+
+* **BARP_REALM**
+
+  The basic authentication realm identifier
+
+Those environment variables take precedence over CLI arguments. Authentication
+principals are additive (i.e. they will not remove entities from
+the configuration file).
+Principals are defined via environment variables prefixed with *BARP_USERNAME_*
+(e.g. BARP_USERNAME_1=test). The values are the authentication username. The
+password can be defined using the prefix *BARP_PASSWORD_*
+(e.g. BARP_PASSWORD_1=password_for_test). If no password is defined a random
+string is generated and emitted on stdout. The generated password is not very
+secure and should only be used for testing/debugging purposes.

--- a/assets/authn.yaml
+++ b/assets/authn.yaml
@@ -1,5 +1,7 @@
-users:
-  - username: Angel
-    password: Barrera
-  - username: Pepe
-    password: Gotera
+---
+users: []
+# users:
+#   - username: Angel
+#     password: Barrera
+#   - username: Pepe
+#     password: Gotera

--- a/examples/authn.yaml
+++ b/examples/authn.yaml
@@ -1,0 +1,5 @@
+---
+
+users:
+  - username: cli
+    password: cli

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,36 @@
+---
+
+version: '2.4'
+
+services:
+  cli_mount:
+    image: barp
+    build: ..
+    command:
+      - serve
+      - '-upstream'
+      - 'http://target:3000'
+      - '-auth-config'
+      - '/authn.yaml'
+    volumes:
+      - './authn.yaml:/authn.yaml:ro'
+    ports:
+      - '127.0.0.1:12380:11811'
+    depends_on:
+      - target
+  env:
+    image: barp
+    build: ..
+    environment:
+      BARP_UPSTREAM: 'http://target:3000'
+      BARP_USERNAME_env: env
+      BARP_PASSWORD_env: env
+    ports:
+      - '127.0.0.1:12381:11811'
+    depends_on:
+      - target
+  target:
+    image: kennship/http-echo
+    environment:
+      PORT: 3000
+      SERVICE_NAME: 'my-app'

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -1,9 +1,23 @@
 package proxy
 
 import (
+	"fmt"
 	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
+)
+
+const (
+	envPrefix            = "BARP"
+	randomPasswordLength = 24
+	randomPasswordPool   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"abcdefghijklmnopqrstuvwxyz" +
+		"0123456789"
 )
 
 // Authn Contains a list of users
@@ -17,16 +31,101 @@ type User struct {
 	Password string `yaml:"password"`
 }
 
-// ParseConfig read a configuration file in the path `location` and returns an Authn object
-func ParseConfig(location *string) (*Authn, error) {
-	data, err := ioutil.ReadFile(*location)
-	if err != nil {
-		return nil, err
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func NewAuthn() *Authn {
+	return &Authn{}
+}
+
+// Merges the data from the provided object and returns self
+func (a *Authn) Merge(other *Authn) error {
+	a.Users = append(a.Users, other.Users...)
+
+	return nil
+}
+
+func (a *Authn) Validate() error {
+	if len(a.Users) == 0 {
+		return fmt.Errorf("no authentication principals configured")
 	}
-	authn := Authn{}
-	err = yaml.Unmarshal([]byte(data), &authn)
-	if err != nil {
-		return nil, err
+
+	return nil
+}
+
+func (a *Authn) AddUser(username string, password string) error {
+	if len(username) == 0 {
+		return fmt.Errorf("username must not be empty")
 	}
-	return &authn, nil
+
+	if len(password) == 0 {
+		password = randomPassword()
+
+		log.Printf("Generating random password for %s: %s", username, password)
+	}
+
+	a.Users = append(a.Users, User{
+		Username: username,
+		Password: password,
+	})
+
+	return nil
+}
+
+func (a *Authn) ParseEnvironment() error {
+	prefix := strings.Join([]string{envPrefix, "USERNAME", ""}, "_")
+
+	for _, e := range os.Environ() {
+		pair := strings.SplitN(e, "=", 2)
+		key, value := pair[0], pair[1]
+		postfix := strings.TrimPrefix(key, prefix)
+
+		if postfix == key {
+			continue
+		}
+
+		lookup := strings.Join([]string{envPrefix, "PASSWORD", postfix}, "_")
+		username := strings.TrimSpace(value)
+		password := os.Getenv(lookup)
+
+		if err := a.AddUser(username, password); err != nil {
+			return fmt.Errorf("invalid environment variable %s: %v", key, err)
+		}
+	}
+
+	return nil
+}
+
+// ParseConfig read a configuration file in the path `location` and returns self
+func (a *Authn) ParseFile(location string) error {
+	data, err := ioutil.ReadFile(location)
+	if err != nil {
+		return err
+	}
+
+	authn := NewAuthn()
+	err = yaml.Unmarshal([]byte(data), authn)
+	if err != nil {
+		return err
+	}
+
+	err = a.Merge(authn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func randomPassword() string {
+	var b strings.Builder
+
+	pool := []rune(randomPasswordPool)
+
+	for i := 0; i < randomPasswordLength; i++ {
+		selection := rand.Intn(len(pool))
+		b.WriteRune(pool[selection])
+	}
+	return b.String()
 }


### PR DESCRIPTION
the server instructions and authentication principals can be
configured via environment variables. this allows for an easier
deployment via docker/kubernetes, as you no longer need to mount
a configuration volume.
the configuration variables overwrite and settings from the CLI
if defined.